### PR TITLE
ci: drop duplicate post-merge CI re-run on push to main (#113)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,8 +6,6 @@ name: CI
 on:
   pull_request:
     branches: [main, test]
-  push:
-    branches: [main]
   workflow_dispatch: {}
 
 concurrency:
@@ -42,7 +40,7 @@ jobs:
               - '!LICENSE'
       - id: tier
         run: |
-          if [[ "${{ github.base_ref }}" == "main" || "${{ github.ref }}" == "refs/heads/main" ]]; then
+          if [[ "${{ github.base_ref }}" == "main" ]]; then
             echo "is-main=true" >> "$GITHUB_OUTPUT"
           else
             echo "is-main=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Promotes `test` → `main` (1 commit).

- ci: drop duplicate post-merge CI re-run on push to main (#113)

Closes qualithm/dx#59
