### PR TITLE
feat(audit): keep scan-failure issues off the Engineering board (Decision #66) (#115)

### DIFF
--- a/.github/actions/report-scan-failure/action.yaml
+++ b/.github/actions/report-scan-failure/action.yaml
@@ -2,9 +2,11 @@
 
 name: "Report or resolve scan failure"
 description: >
-  Files (or bumps) a board-ready issue when a scheduled scan step genuinely fails, or closes it once
-  the scan is green again and nobody has claimed it yet. Dedupes on the issue title, so re-runs of a
-  still-failing scan never pile up duplicate issues.
+  Files (or bumps) a `security-audit`-labeled issue when a scheduled scan step genuinely fails, or
+  closes it once the scan is green again and nobody has claimed it yet. Dedupes on the issue title,
+  so re-runs of a still-failing scan never pile up duplicate issues. The label deliberately keeps
+  these off the Engineering board by default (Decision #66) — promote one manually with `dx project
+  add` if it turns into real, multi-session work.
 inputs:
   mode:
     description: "report (scan just failed) or resolve (scan just passed)"

--- a/.github/actions/report-scan-failure/run.sh
+++ b/.github/actions/report-scan-failure/run.sh
@@ -10,6 +10,14 @@ existing="$(gh issue list --repo "$REPO" --state open --search "\"${TITLE}\"" \
 
 case "$MODE" in
 report)
+  # security-audit deliberately keeps these off the Engineering board (issue-templates/
+  # add-to-project.yaml excludes it) — see Decision #66:
+  # https://github.com/orgs/qualithm/discussions/66. The label must exist before `gh issue
+  # create --label` can attach it, so ensure it every run; --force makes this idempotent.
+  gh label create security-audit --repo "$REPO" --color "b60205" --force \
+    --description "Automated scan failure filed by report-scan-failure; kept off the Engineering board (Decision #66)" \
+    >/dev/null
+
   if [[ -n "$existing" ]]; then
     gh issue comment "$existing" --repo "$REPO" --body "Still failing as of ${RUN_URL}."
     echo "report-scan-failure: bumped existing issue #${existing}"
@@ -30,7 +38,7 @@ addressing the finding.
 
 ### Links
 - Failing run: ${RUN_URL}"
-    url="$(gh issue create --repo "$REPO" --title "$TITLE" --body "$body")"
+    url="$(gh issue create --repo "$REPO" --title "$TITLE" --body "$body" --label security-audit)"
     echo "report-scan-failure: filed ${url}"
   fi
   ;;

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -17,3 +17,7 @@ jobs:
         with:
           project-url: https://github.com/orgs/qualithm/projects/3
           github-token: ${{ steps.app.outputs.token }}
+          # Automated scan-failure issues (report-scan-failure) stay off the board by
+          # default — see Decision #66: https://github.com/orgs/qualithm/discussions/66.
+          labeled: security-audit
+          label-operator: NOT


### PR DESCRIPTION
Promotes `test` → `main` (1 commit).

- feat(audit): keep scan-failure issues off the Engineering board (Decision #66) (#115)